### PR TITLE
added option --holdver to ccr, which is

### DIFF
--- a/ccr
+++ b/ccr
@@ -468,8 +468,8 @@ while [[ $1 ]]; do
     '--noedit') noedit='1' ;;
     '--ccronly') ccronly='1' ;;
     '--devel') devel='1' ;;
-    '--skipinteg') MAKEPKGOPTS="--skipinteg" ;;
-    '--holdver') MAKEPKGOPTS="--holdver" ;;
+    '--skipinteg') MAKEPKGOPTS="${MAKEPKGOPTS} --skipinteg" ;;
+    '--holdver') MAKEPKGOPTS="${MAKEPKGOPTS} --holdver" ;;
     '--') shift ; packageargs+=("$@") ; break ;;
     -*) echo "ccr: Option \`$1' is not valid." ; exit 5 ;;
     *) packageargs+=("$1") ;;


### PR DESCRIPTION
sent to MAKEPKGOPTS

I think this could be useful in cases where a newer version in a repository is broken for whatever reason.. What do you think?
