### PR TITLE
Source makepkg for every build

### DIFF
--- a/ccr
+++ b/ccr
@@ -325,7 +325,6 @@ ccrinstall() {
 installhandling() {
   packageargs=("$@")
   getignoredpackages
-  sourcemakepkgconf
   # Figure out all of the packages that need to be installed
   for package in "${packageargs[@]}"; do
     # Determine whether package is in pacman repos


### PR DESCRIPTION
Some packages in ccr set variables, e.g. PKGEXT to change the package extension, in PKGBUILD. Packages, which are build and installed after this in the same ccr process, can't find the package, because the PKGEXT variable is still set to the one changed in the former PKGBUILD file. For example the google-earth package sets this variable and ccr stops installing other files, because it can't find those binary packages produced by makepkg.

These changes source the makepkg.conf files for every build and overwrite the changes to variables in the makepkg files.
